### PR TITLE
ref(alloc): Switch to mimalloc as the default allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +1264,15 @@ dependencies = [
  "rand",
  "rand_xoshiro",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1956,6 +1975,7 @@ dependencies = [
  "hyper-util",
  "metrics",
  "metrics-exporter-dogstatsd",
+ "mimalloc",
  "regex",
  "sentry",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ figment = { version = "0.10.19", features = ["yaml", "test", "env"] }
 brotli = "8.0.2"
 zstd = "0.13.3"
 metrics-exporter-dogstatsd = "0.9.6"
+mimalloc = { version = "0.1.48", features = ["v3", "override"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ mod request;
 mod service;
 mod state;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser, Debug)]
 struct Args {
     /// Path to the configuration file


### PR DESCRIPTION
Switches the default allocator to mimalloc v3 for improved performance and reduced memory fragmentation. MiMalloc is already used by Relay successfully.

Important, the `v3` feature is enabled, the maintainer recommends in some issues to use `v3` over `v2`. The `override` feature is enabled to override `malloc`, meaning C dependencies also pickup mimalloc (less relevant for this usecase though).