### PR TITLE
feat: Use distribution types for histograms

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,6 +34,7 @@ pub fn init(metrics_config: MetricsConfig) {
             .expect("Failed to parse metrics address")
             .set_global_prefix("sentrymirror")
             .with_global_labels(labels)
+            .send_histograms_as_distributions(true)
             .build()
             .expect("Could not create DogStatsD exporter");
 


### PR DESCRIPTION
Switch to using distribution types instead of agent histograms. This should be the default but being explicit shouldn't hurt.