### PR TITLE
fix: Handle empty content-encoding header

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -241,7 +241,7 @@ pub fn decode_body(encoding_header: &HeaderValue, body: &Bytes) -> Result<Bytes,
                 Err(BodyError::CouldNotDecode(err))
             }
         }
-    } else if encoding_value == "" {
+    } else if encoding_value.is_empty() {
         // Some clients misbehave and send an empty content-encoding value.
         Ok(Bytes::from(body_vec))
     } else {


### PR DESCRIPTION
While this is not compliant with http standards, clients can misbehave and we can treat an empty encoding as not encoded instead of an error.