### PR TITLE
fix: Add minidump to url path segment allow list

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -437,10 +437,7 @@ mod tests {
         assert!(res.is_ok());
         let req = res.unwrap();
         let uri = req.uri();
-        assert_eq!(
-            uri,
-            "https://o789.ingest.sentry.io/api/6789/minidump/"
-        );
+        assert_eq!(uri, "https://o789.ingest.sentry.io/api/6789/minidump/");
     }
 
     #[test]


### PR DESCRIPTION
Allow minidumps paths to be proxied correctly.