### PR TITLE
feat: Add light-weight envelope parsing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn emit_version() {
 
     let release_name = format!("{package_name}@{package_version}+{git_commit_sha}");
     fs::write("./VERSION", &release_name).expect("Unable to write version");
-    println!("cargo:rustc-env=SENTRY_MIRROR_VERSION={}", &release_name);
+    println!("cargo:rustc-env=SENTRY_MIRROR_VERSION={}", release_name);
 }
 
 fn main() {

--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -165,7 +165,7 @@ pub fn make_key_map(config: &ConfigData) -> HashMap<String, DsnKeyRing> {
 
 pub fn format_key_map(keymap: &HashMap<String, DsnKeyRing>) -> String {
     let mut out = String::new();
-    for (_, keyring) in keymap.iter() {
+    for keyring in keymap.values() {
         out.push_str(format!("Inbound: {}\n", keyring.inbound).as_ref());
         out.push_str("Outbound:\n");
         for outbound in keyring.outbound.iter() {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -33,7 +33,6 @@ impl Envelope {
             bytes.extend_from_slice(&item_bytes);
             bytes.extend(b"\n");
         }
-        bytes.trim_ascii();
 
         Bytes::from(bytes)
     }
@@ -187,10 +186,7 @@ mod tests {
     fn test_parse_envelope_empty() {
         let body = b"";
         let res = parse(body);
-        assert!(res.is_some());
-        let envelope = res.expect("should be some");
-        assert_eq!(envelope.header, Value::Null);
-        assert_eq!(envelope.items.len(), 0);
+        assert!(res.is_none());
     }
 
     #[test]
@@ -222,6 +218,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_envelope_item_length_overflow() {
+        let mut body = Vec::new();
+        // Envelope header
+        body.extend_from_slice(
+            br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
+        );
+        body.push(b'\n');
+        // Feedback item with overflow length attribute
+        body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":400000}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+
+        let res = parse(body.as_slice());
+        assert!(res.is_none());
+    }
+
+    #[test]
     fn test_parse_envelope_items_invalid_header() {
         let mut body = Vec::new();
         // Envelope header
@@ -229,15 +241,12 @@ mod tests {
             br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
         );
         body.push(b'\n');
+        // Item header is not json
         body.extend_from_slice(b"lol-not-json\n");
         body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
 
         let res = parse(body.as_slice());
-        assert!(res.is_some());
-        let envelope = res.expect("should be some");
-        assert_eq!(envelope.header.get("dsn").expect("should be there"), "https://deadbeef@ingest.sentry.io/123");
-
-        assert_eq!(envelope.items.len(), 0);
+        assert!(res.is_none());
     }
 
     #[test]

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -181,4 +181,23 @@ mod tests {
         assert_eq!(envelope.items[1].header.get("type").expect("should be there"), "event");
         assert_eq!(envelope.items[1].body.to_vec(), b"{\"event_id\":\"original-id\",\"message\":\"test\"}");
     }
+
+    #[test]
+    fn test_parse_envelope_items_invalid_header() {
+        let mut body = Vec::new();
+        // Envelope header
+        body.extend_from_slice(
+            br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
+        );
+        body.push(b'\n');
+        body.extend_from_slice(b"lol-not-json\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+
+        let res = parse(body.as_slice());
+        assert!(res.is_some());
+        let envelope = res.expect("should be some");
+        assert_eq!(envelope.header.get("dsn").expect("should be there"), "https://deadbeef@ingest.sentry.io/123");
+
+        assert_eq!(envelope.items.len(), 0);
+    }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -2,25 +2,13 @@
 use hyper::body::Bytes;
 use serde_json::Value;
 use tracing::{debug, warn};
-/*
- *
-Envelope
-- header_json
-- header_bytes
-- body_bytes
-- vec<envelopeitem>
-
-EnvelopeItem
-- header_json
-- header_bytes
-- item_bytes
-*/
 
 /// We don't need to fully parse all envelopes.
 /// A partial parse of the body into the envelope
 /// header and items lets us apply sampling, event id rotation
 /// parsing 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Envelope {
     /// The parsed json value of the header.
     pub header: Value,
@@ -31,6 +19,7 @@ pub struct Envelope {
 
 impl Envelope {
     /// Convert the envelope into Bytes that contains the envelope header, items and newlines.
+    #[allow(dead_code)]
     pub fn to_bytes(&self) -> Bytes {
         let mut bytes = vec![];
         let Ok(header_bytes) = serde_json::to_vec(&self.header) else {
@@ -51,6 +40,7 @@ impl Envelope {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct EnvelopeItem {
     /// The parsed json value of the header.
     pub header: Value,
@@ -76,6 +66,7 @@ impl EnvelopeItem {
 
 /// Extract an Envelope out of a byte stream
 /// Will return None when no items can be parsed, or the body has no newlines.
+#[allow(dead_code)]
 pub fn parse(body: &[u8]) -> Option<Envelope> {
     // Split the envelope header off if possible
     let mut body_chunks = body.splitn(2, |&x| x == b'\n');

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -162,7 +162,10 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
             }
         };
         // Position of where the current item ends.
-        let data_end = data_start + length;
+        let Some(data_end) = data_start.checked_add(length) else {
+            warn!("Data length {length} overflows u64");
+            return vec![];
+        };
         if data_end > body.len() {
             warn!("Data length {length} exceeds remaining bytes");
             return vec![];
@@ -218,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_envelope_item_length_overflow() {
+    fn test_parse_envelope_item_length_overflow_body() {
         let mut body = Vec::new();
         // Envelope header
         body.extend_from_slice(
@@ -230,6 +233,25 @@ mod tests {
         body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
         // Feedback item with overflow length attribute
         body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":400000}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+
+        let res = parse(body.as_slice());
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn test_parse_envelope_item_length_overflow_u64() {
+        let mut body = Vec::new();
+        // Envelope header
+        body.extend_from_slice(
+            br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
+        );
+        body.push(b'\n');
+        // Feedback item that is ok
+        body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":40}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+        // Feedback item with overflow length attribute
+        body.extend(format!("{{\"type\":\"feedback\",\"length\":{}}}\n", usize::MAX).as_bytes());
         body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
 
         let res = parse(body.as_slice());

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -22,14 +22,56 @@ EnvelopeItem
 /// parsing 
 #[derive(Debug, Clone)]
 pub struct Envelope {
+    /// The parsed json value of the header.
     pub header: Value,
+
+    /// Collection of items in the envelope.
     pub items: Vec<EnvelopeItem>,
+}
+
+impl Envelope {
+    /// Convert the envelope into Bytes that contains the envelope header, items and newlines.
+    pub fn to_bytes(&self) -> Bytes {
+        let mut bytes = vec![];
+        let Ok(header_bytes) = serde_json::to_vec(&self.header) else {
+            return Bytes::new();
+        };
+        bytes.extend(header_bytes);
+        bytes.extend(b"\n");
+
+        for item in self.items.iter() {
+            let item_bytes = item.to_bytes();
+            bytes.extend_from_slice(&item_bytes);
+            bytes.extend(b"\n");
+        }
+        bytes.trim_ascii();
+
+        Bytes::from(bytes)
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct EnvelopeItem {
+    /// The parsed json value of the header.
     pub header: Value,
+
+    /// Bytes of the envelope item.
     pub body: Bytes,
+}
+
+impl EnvelopeItem {
+    /// Convert the item into bytes that can be added to an envelope bytes.
+    pub fn to_bytes(&self) -> Bytes {
+        let mut bytes = vec![];
+        let Ok(header_bytes) = serde_json::to_vec(&self.header) else {
+            return Bytes::new();
+        };
+        bytes.extend(header_bytes);
+        bytes.extend(b"\n");
+        bytes.extend(self.body.to_vec());
+
+        Bytes::from(bytes)
+    }
 }
 
 /// Extract an Envelope out of a byte stream
@@ -199,5 +241,27 @@ mod tests {
         assert_eq!(envelope.header.get("dsn").expect("should be there"), "https://deadbeef@ingest.sentry.io/123");
 
         assert_eq!(envelope.items.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_and_to_bytes() {
+        let mut body = Vec::new();
+        // Envelope header
+        body.extend_from_slice(
+            br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
+        );
+        body.push(b'\n');
+        // Feedback item
+        body.extend_from_slice(b"{\"length\":40,\"type\":\"feedback\"}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+        // Event item
+        body.extend_from_slice(b"{\"length\":43,\"type\":\"event\"}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"message\":\"test\"}\n");
+
+        let parsed = parse(body.as_slice());
+        assert!(parsed.is_some());
+        let envelope = parsed.expect("should be some");
+        let bytes = envelope.to_bytes();
+        assert_eq!(bytes.to_vec(), body, "body shape should be preserved");
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -75,6 +75,7 @@ impl EnvelopeItem {
 }
 
 /// Extract an Envelope out of a byte stream
+/// Will return None when no items can be parsed, or the body has no newlines.
 pub fn parse(body: &[u8]) -> Option<Envelope> {
     // Split the envelope header off if possible
     let mut body_chunks = body.splitn(2, |&x| x == b'\n');
@@ -85,6 +86,11 @@ pub fn parse(body: &[u8]) -> Option<Envelope> {
         None => return None,
     };
     let items = parse_envelope_items(body_chunks.next());
+    // If we failed to parse any items, we don't want a partial envelope
+    if items.is_empty() {
+        return None;
+    }
+
     let envelope = Envelope {
         header: envelope_header,
         items,
@@ -126,7 +132,7 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
             Some(pos) => position + pos,
             None => {
                 warn!("Could not find item header line ending");
-                return items;
+                return vec![];
             }
         };
 
@@ -135,14 +141,14 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
             Ok(h) => h,
             Err(e) => {
                 warn!("Could not convert item header to String {0}", e);
-                return items;
+                return vec![];
             }
         };
         let header_json: Value = match serde_json::from_str(&header_str) {
             Ok(v) => v,
             Err(e) => {
                 warn!("Could not convert item header to JSON {0}", e);
-                return items;
+                return vec![];
             }
         };
 
@@ -263,5 +269,46 @@ mod tests {
         let envelope = parsed.expect("should be some");
         let bytes = envelope.to_bytes();
         assert_eq!(bytes.to_vec(), body, "body shape should be preserved");
+    }
+
+    #[test]
+    fn test_parse_body_invalid_multiline_item() {
+        // When items don't have a length, the item is supposed to be all on one line.
+        // This test covers non-compliant behavior as the item has no length and is multiline
+        let mut body = Vec::new();
+        body.extend_from_slice(b"{}\n");
+        body.extend_from_slice(b"{\"type\":\"event\"}\n");
+        body.extend_from_slice(b"{\"key\":\"value\", \"event_id\":\"replace\"}");
+        body.push(b'\n');
+        body.extend_from_slice(b"{\"type\":\"feedback\"}\n");
+        body.extend_from_slice(b"{\"event_id\":\"replace\", \n");
+        body.extend_from_slice(b"\"contexts\":{\"feedback\":{}}}");
+
+        let parsed = parse(body.as_slice());
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_body_binary_data() {
+        let mut body = Vec::new();
+
+        let binary_data: Vec<u8> = vec![0xFF, 0xFE, 0x00, 0x0A, 0x80, 0x90, 0xA0, 0xB0, 0xC0];
+        let binary_header = format!(
+            "{{\"type\":\"attachment\",\"length\":{}}}\n",
+            binary_data.len()
+        );
+
+        body.extend_from_slice(b"{}\n");
+        body.extend_from_slice(binary_header.as_bytes());
+        body.extend_from_slice(&binary_data);
+        body.push(b'\n');
+
+        let parsed = parse(body.as_slice());
+        assert!(parsed.is_some());
+
+        let envelope = parsed.expect("should be some");
+        assert_eq!(envelope.items.len(), 1);
+        assert_eq!(envelope.items[0].header.get("type").unwrap(), "attachment");
+        assert_eq!(envelope.items[0].body.to_vec(), binary_data, "should preserve binary data");
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,4 +1,3 @@
-
 use hyper::body::Bytes;
 use serde_json::Value;
 use tracing::{debug, warn};
@@ -6,7 +5,7 @@ use tracing::{debug, warn};
 /// We don't need to fully parse all envelopes.
 /// A partial parse of the body into the envelope
 /// header and items lets us apply sampling, event id rotation
-/// parsing 
+/// parsing
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Envelope {
@@ -175,7 +174,10 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
         // Move to next block (skip past data and the trailing \n)
         position = data_end + 1;
 
-        let item = EnvelopeItem {header: header_json, body: item_bytes};
+        let item = EnvelopeItem {
+            header: header_json,
+            body: item_bytes,
+        };
         items.push(item);
     }
     items
@@ -210,14 +212,35 @@ mod tests {
         let res = parse(body.as_slice());
         assert!(res.is_some());
         let envelope = res.expect("should be some");
-        assert_eq!(envelope.header.get("dsn").expect("should be there"), "https://deadbeef@ingest.sentry.io/123");
+        assert_eq!(
+            envelope.header.get("dsn").expect("should be there"),
+            "https://deadbeef@ingest.sentry.io/123"
+        );
 
         assert_eq!(envelope.items.len(), 2);
-        assert_eq!(envelope.items[0].header.get("type").expect("should be there"), "feedback");
-        assert_eq!(envelope.items[0].body.to_vec(), b"{\"event_id\":\"original-id\",\"contexts\":{}}");
+        assert_eq!(
+            envelope.items[0]
+                .header
+                .get("type")
+                .expect("should be there"),
+            "feedback"
+        );
+        assert_eq!(
+            envelope.items[0].body.to_vec(),
+            b"{\"event_id\":\"original-id\",\"contexts\":{}}"
+        );
 
-        assert_eq!(envelope.items[1].header.get("type").expect("should be there"), "event");
-        assert_eq!(envelope.items[1].body.to_vec(), b"{\"event_id\":\"original-id\",\"message\":\"test\"}");
+        assert_eq!(
+            envelope.items[1]
+                .header
+                .get("type")
+                .expect("should be there"),
+            "event"
+        );
+        assert_eq!(
+            envelope.items[1].body.to_vec(),
+            b"{\"event_id\":\"original-id\",\"message\":\"test\"}"
+        );
     }
 
     #[test]
@@ -334,6 +357,10 @@ mod tests {
         let envelope = parsed.expect("should be some");
         assert_eq!(envelope.items.len(), 1);
         assert_eq!(envelope.items[0].header.get("type").unwrap(), "attachment");
-        assert_eq!(envelope.items[0].body.to_vec(), binary_data, "should preserve binary data");
+        assert_eq!(
+            envelope.items[0].body.to_vec(),
+            binary_data,
+            "should preserve binary data"
+        );
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -165,7 +165,7 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
         let data_end = data_start + length;
         if data_end > body.len() {
             warn!("Data length {length} exceeds remaining bytes");
-            return items;
+            return vec![];
         }
         let item_bytes = Bytes::from((body[data_start..data_end]).to_owned());
 
@@ -225,6 +225,9 @@ mod tests {
             br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
         );
         body.push(b'\n');
+        // Feedback item that is ok
+        body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":40}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
         // Feedback item with overflow length attribute
         body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":400000}\n");
         body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -70,9 +70,9 @@ pub fn parse(body: &[u8]) -> Option<Envelope> {
     let mut body_chunks = body.splitn(2, |&x| x == b'\n');
 
     // Replace dsn and id values in envelope header
-    let envelope_header = match body_chunks.next() {
-        Some(bytes) => parse_envelope_header(bytes),
-        None => return None,
+    let envelope_header = {
+        let bytes = body_chunks.next()?;
+        parse_envelope_header(bytes)
     };
     let items = parse_envelope_items(body_chunks.next());
     // If we failed to parse any items, we don't want a partial envelope

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,0 +1,184 @@
+
+use hyper::body::Bytes;
+use serde_json::Value;
+use tracing::{debug, warn};
+/*
+ *
+Envelope
+- header_json
+- header_bytes
+- body_bytes
+- vec<envelopeitem>
+
+EnvelopeItem
+- header_json
+- header_bytes
+- item_bytes
+*/
+
+/// We don't need to fully parse all envelopes.
+/// A partial parse of the body into the envelope
+/// header and items lets us apply sampling, event id rotation
+/// parsing 
+#[derive(Debug, Clone)]
+pub struct Envelope {
+    pub header: Value,
+    pub items: Vec<EnvelopeItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnvelopeItem {
+    pub header: Value,
+    pub body: Bytes,
+}
+
+/// Extract an Envelope out of a byte stream
+pub fn parse(body: &[u8]) -> Option<Envelope> {
+    // Split the envelope header off if possible
+    let mut body_chunks = body.splitn(2, |&x| x == b'\n');
+
+    // Replace dsn and id values in envelope header
+    let envelope_header = match body_chunks.next() {
+        Some(bytes) => parse_envelope_header(bytes),
+        None => return None,
+    };
+    let items = parse_envelope_items(body_chunks.next());
+    let envelope = Envelope {
+        header: envelope_header,
+        items,
+    };
+
+    Some(envelope)
+}
+
+fn parse_envelope_header(header: &[u8]) -> Value {
+    // We don't want to copy the entire body to String as
+    // replays have blobs in them, and we only need the header.
+    let message_header = match String::from_utf8(header.to_vec()) {
+        Ok(h) => h,
+        Err(e) => {
+            warn!("Could not convert envelope header to String {0}", e);
+
+            return Value::Null;
+        }
+    };
+    match serde_json::from_str(&message_header) {
+        Ok(data) => data,
+        Err(_) => Value::Null,
+    }
+}
+
+fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
+    let body = match body {
+        Some(body) => body,
+        None => return vec![],
+    };
+
+    let mut position = 0;
+    let mut items: Vec<EnvelopeItem> = vec![];
+
+    // Iterate over item blocks in envelope
+    while position < body.len() {
+        // Find the end of the item header line (first \n)
+        let header_end = match body[position..].iter().position(|&x| x == b'\n') {
+            Some(pos) => position + pos,
+            None => {
+                warn!("Could not find item header line ending");
+                return items;
+            }
+        };
+
+        let header_slice = &body[position..header_end];
+        let header_str = match String::from_utf8(header_slice.to_vec()) {
+            Ok(h) => h,
+            Err(e) => {
+                warn!("Could not convert item header to String {0}", e);
+                return items;
+            }
+        };
+        let header_json: Value = match serde_json::from_str(&header_str) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Could not convert item header to JSON {0}", e);
+                return items;
+            }
+        };
+
+        // Item header and payload are separated by \n
+        let data_start = header_end + 1;
+
+        // Read the item length from the header. Or infer the `length` based on newlines.
+        // When items don't have `length` defined, payloads are assumed to be on a
+        // single line.
+        // Ref: https://develop.sentry.dev/sdk/data-model/envelopes/#items
+        let length = match header_json.get("length").and_then(|v| v.as_u64()) {
+            Some(len) => len as usize,
+            None => {
+                if let Some(next_line) = body[data_start..].iter().position(|&x| x == b'\n') {
+                    next_line
+                } else {
+                    // Assume we are at the terminal item in the envelope.
+                    debug!("Payload missing length, and no newline could be found");
+                    body.len() - data_start
+                }
+            }
+        };
+        // Position of where the current item ends.
+        let data_end = data_start + length;
+        if data_end > body.len() {
+            warn!("Data length {length} exceeds remaining bytes");
+            return items;
+        }
+        let item_bytes = Bytes::from((body[data_start..data_end]).to_owned());
+
+        // Move to next block (skip past data and the trailing \n)
+        position = data_end + 1;
+
+        let item = EnvelopeItem {header: header_json, body: item_bytes};
+        items.push(item);
+    }
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_envelope_empty() {
+        let body = b"";
+        let res = parse(body);
+        assert!(res.is_some());
+        let envelope = res.expect("should be some");
+        assert_eq!(envelope.header, Value::Null);
+        assert_eq!(envelope.items.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_envelope_items() {
+        let mut body = Vec::new();
+        // Envelope header
+        body.extend_from_slice(
+            br#"{"dsn":"https://deadbeef@ingest.sentry.io/123","event_id":"original-id"}"#,
+        );
+        body.push(b'\n');
+        // Feedback item
+        body.extend_from_slice(b"{\"type\":\"feedback\",\"length\":40}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"contexts\":{}}\n");
+        // Event item
+        body.extend_from_slice(b"{\"type\":\"event\",\"length\":43}\n");
+        body.extend_from_slice(b"{\"event_id\":\"original-id\",\"message\":\"test\"}\n");
+
+        let res = parse(body.as_slice());
+        assert!(res.is_some());
+        let envelope = res.expect("should be some");
+        assert_eq!(envelope.header.get("dsn").expect("should be there"), "https://deadbeef@ingest.sentry.io/123");
+
+        assert_eq!(envelope.items.len(), 2);
+        assert_eq!(envelope.items[0].header.get("type").expect("should be there"), "feedback");
+        assert_eq!(envelope.items[0].body.to_vec(), b"{\"event_id\":\"original-id\",\"contexts\":{}}");
+
+        assert_eq!(envelope.items[1].header.get("type").expect("should be there"), "event");
+        assert_eq!(envelope.items[1].body.to_vec(), b"{\"event_id\":\"original-id\",\"message\":\"test\"}");
+    }
+}

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -88,9 +88,9 @@ pub fn parse(body: &[u8]) -> Option<Envelope> {
     Some(envelope)
 }
 
+/// Extract and parse the envelope header
 fn parse_envelope_header(header: &[u8]) -> Value {
-    // We don't want to copy the entire body to String as
-    // replays have blobs in them, and we only need the header.
+    // envelope headers must be parsable as a string
     let message_header = match String::from_utf8(header.to_vec()) {
         Ok(h) => h,
         Err(e) => {
@@ -99,12 +99,14 @@ fn parse_envelope_header(header: &[u8]) -> Value {
             return Value::Null;
         }
     };
+    // envelope headers must be json
     match serde_json::from_str(&message_header) {
         Ok(data) => data,
         Err(_) => Value::Null,
     }
 }
 
+/// Extract all the envelope items out of a bytes/none
 fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
     let body = match body {
         Some(body) => body,
@@ -114,7 +116,7 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
     let mut position = 0;
     let mut items: Vec<EnvelopeItem> = vec![];
 
-    // Iterate over item blocks in envelope
+    // Parse items until we get to the end of the bytestream
     while position < body.len() {
         // Find the end of the item header line (first \n)
         let header_end = match body[position..].iter().position(|&x| x == b'\n') {
@@ -124,7 +126,7 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
                 return vec![];
             }
         };
-
+        // Item headers must be string + json
         let header_slice = &body[position..header_end];
         let header_str = match String::from_utf8(header_slice.to_vec()) {
             Ok(h) => h,
@@ -160,7 +162,7 @@ fn parse_envelope_items(body: Option<&[u8]>) -> Vec<EnvelopeItem> {
                 }
             }
         };
-        // Position of where the current item ends.
+        // Calculate the end of the envelope item, and handle int overflows
         let Some(data_end) = data_start.checked_add(length) else {
             warn!("Data length {length} overflows u64");
             return vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::state::AppState;
 
 mod config;
 mod dsn;
+mod envelope;
 mod logging;
 mod metrics;
 mod request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -220,9 +220,9 @@ pub fn modify_envelope(
     };
 
     // Replace dsn and id values in envelope header
-    let envelope_header = match body_chunks.next() {
-        Some(bytes) => modify_envelope_header(bytes, outbound, &new_event_id)?,
-        None => return None,
+    let envelope_header = {
+        let bytes = body_chunks.next()?;
+        modify_envelope_header(bytes, outbound, &new_event_id)?
     };
 
     // Filter and mutate envelope items if required.


### PR DESCRIPTION
In trying to add per-category sampling rates, the implementation got really messy as currently parsing and filtering logic are interwoven. To help separate concerns and make sampling easier to add next, I've split out envelope parsing into a separate module and structs.

Parsing envelopes into structures will incur some overhead as there are more allocations/copies being done, but the logic will be simpler to understand and work with. These changes duplicate a bunch of the logic from the `request` module, but my plan is to remove the other copy in a subsequent pull request. I didn't want to it all at once as the diff is pretty large.