### PR TITLE
feat: Add sample_rate per outbound DSN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-dogstatsd",
  "mimalloc",
+ "rand 0.9.4",
  "regex",
  "sentry",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ zstd = "0.13.3"
 metrics-exporter-dogstatsd = "0.9.6"
 mimalloc = { version = "0.1.48", features = ["v3", "override"] }
 uuid = { version = "1.19.0", features = ["v4"] }
+rand = "0.9"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ keys:
       - https://public-key-blue@o456.ingest.us.sentry.io/654321
 ```
 
-You can also enable selective forwarding to an outbound DSN based on envelope item categories,
-and item multipliers:
+You can also enable selective forwarding to an outbound DSN based on envelope item `categories`,
+`sample_rate` and item `multiplier`:
 
 ```yaml
 ip: 0.0.0.0
@@ -38,11 +38,42 @@ keys:
         multiplier: 5
 ```
 
-When `categories` is a non-empty list only those categories will be forwarded. If
-the category list is empty or undefined *all categories* will be forwarded. When `multiplier`
-is used, mirror will copy matching envelope items *n* times. Each copy will have a 
-unique `event_id` assigned to it. Multipliers are useful when you need to amplify writes
-from an application to increase load on a sentry instance.
+When `categories` is a non-empty list, only items with those categories will be
+forwarded to the outbound DSN. If the category list is empty or undefined *all
+categories* will be forwarded. When `multiplier` is used, mirror will copy
+matching envelope items *n* times. Each copy will have a unique `event_id`
+assigned to it. Multipliers are useful when you need to amplify writes from an
+application to increase load on a sentry instance.
+
+Outbound DSN keys can a `sample_rate` defined:
+
+```yaml
+ip: 0.0.0.0
+port: 3000
+keys:
+  - inbound: http://public-key@sentry-mirror.acme.org/1847101
+    outbound:
+      - https://public-key-red@o123.ingest.de.sentry.io/123456
+
+      # Sample all categories at 0.5
+      - dsn: https://public-key-blue@o456.ingest.us.sentry.io/654321
+        sample_rate: 0.5
+
+      # Sample spans at 0.05 and all other categories at 1.0
+      - dsn: https://public-key-blue@o456.ingest.us.sentry.io/654321
+        sample_rate:
+            span: 0.05
+```
+
+The `sample_rate` option is either a mapping of categories and their sample
+rate, or a simple float. When `sample_rate` is defined as a float, it applies to
+*all* categories. When defined as a map, if a category is not defined in the
+`sample_rate` mapping, the rate is assumed to be `1.0`. Sample rates must be
+between `0 - 1.0` inclusive. Out of bounds values emit warnings during startup
+and the values are clamped to the closest boundary.
+
+:warning: Combining `multiplier` and `sample_rate` is a configuration error,
+that should cause the mirror to log an error and ignore the `multiplier` value.
 
 ## Request rewriting
 
@@ -51,6 +82,7 @@ When events are mirrored to outbound DSNs the following modifications may be mad
 1. `sentry_key` component of `Authorization` and `X-Sentry-Auth` headers will be replaced.
 2. `dsn` in envelope headers will be replaced.
 3. `trace.public_key` in envelope headers will be replaced.
+3. `trace.sample_rate` is recalculated if `sample_rate` is defined on the DSN configuration.
 4. Content-Length, Content-Encoding, Host, X-Forwarded-For headers will be removed.
 
 sentry-mirror will send outbound requests concurrently and respond with the response 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ matching envelope items *n* times. Each copy will have a unique `event_id`
 assigned to it. Multipliers are useful when you need to amplify writes from an
 application to increase load on a sentry instance.
 
-Outbound DSN keys can a `sample_rate` defined:
+Outbound DSN keys can have a `sample_rate` defined:
 
 ```yaml
 ip: 0.0.0.0
@@ -72,8 +72,14 @@ rate, or a simple float. When `sample_rate` is defined as a float, it applies to
 between `0 - 1.0` inclusive. Out of bounds values emit warnings during startup
 and the values are clamped to the closest boundary.
 
-:warning: Combining `multiplier` and `sample_rate` is a configuration error,
-that should cause the mirror to log an error and ignore the `multiplier` value.
+Sampling decisions are made once per envelope, using the category of the first
+item that is not an `attachment`. An envelope is either forwarded whole or
+dropped whole, so attachments are never separated from the event they belong to.
+Requests that are not envelopes, such as minidumps, use the rate that applies to
+all categories, and are not sampled when only per-category rates are configured.
+
+:warning: Combining `multiplier` and `sample_rate` is a configuration error.
+The mirror logs an error during startup and ignores the `multiplier` value.
 
 ## Request rewriting
 
@@ -82,8 +88,8 @@ When events are mirrored to outbound DSNs the following modifications may be mad
 1. `sentry_key` component of `Authorization` and `X-Sentry-Auth` headers will be replaced.
 2. `dsn` in envelope headers will be replaced.
 3. `trace.public_key` in envelope headers will be replaced.
-3. `trace.sample_rate` is recalculated if `sample_rate` is defined on the DSN configuration.
-4. Content-Length, Content-Encoding, Host, X-Forwarded-For headers will be removed.
+4. `trace.sample_rate` is recalculated if `sample_rate` is defined on the DSN configuration.
+5. Content-Length, Content-Encoding, Host, X-Forwarded-For headers will be removed.
 
 sentry-mirror will send outbound requests concurrently and respond with the response 
 body of the first outbound key.

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,16 @@ use std::fs;
 
 use crate::logging::LogFormat;
 
+/// The sampling rate applied to an outbound DSN. Either a single rate used for
+/// all categories, or a mapping of category to rate. Categories that are absent
+/// from the mapping are not sampled.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SampleRateConfig {
+    Uniform(f64),
+    PerCategory(BTreeMap<String, f64>),
+}
+
 /// Configuration data for Outbound destination DSNs.
 /// Each outbound DSN can optionally include a list of
 /// `categories` that the DSN is interested in.Envelope
@@ -26,6 +36,8 @@ pub enum OutboundConfig {
         categories: Option<Vec<String>>,
         #[serde(default = "default_multiplier")]
         multiplier: usize,
+        #[serde(default)]
+        sample_rate: Option<SampleRateConfig>,
     },
 }
 
@@ -155,12 +167,17 @@ mod tests {
                 dsn,
                 categories,
                 multiplier,
+                sample_rate,
             } => {
                 assert_eq!(dsn, "https://key@sentry.io/123");
                 assert_eq!(categories, Some(vec!["event".to_string()]));
                 assert_eq!(
                     multiplier, 1,
                     "multiply should default to 1 when not specified"
+                );
+                assert_eq!(
+                    sample_rate, None,
+                    "sample_rate should be None when not specified"
                 );
             }
             _ => panic!("Expected Detailed variant"),
@@ -178,6 +195,7 @@ mod tests {
                 dsn,
                 categories: _,
                 multiplier,
+                sample_rate: _,
             } => {
                 assert_eq!(dsn, "https://key@sentry.io/123");
                 assert_eq!(
@@ -200,6 +218,7 @@ mod tests {
                 dsn,
                 categories,
                 multiplier,
+                sample_rate,
             } => {
                 assert_eq!(dsn, "https://key@sentry.io/123");
                 assert_eq!(
@@ -207,8 +226,94 @@ mod tests {
                     "categories should be None when not specified"
                 );
                 assert_eq!(multiplier, 1, "multiply should default to 1");
+                assert_eq!(sample_rate, None, "sample_rate should default to None");
             }
             _ => panic!("Expected Detailed variant"),
         }
+    }
+
+    fn get_sample_rate(json: &str) -> Option<SampleRateConfig> {
+        let config: OutboundConfig = serde_json::from_str(json).unwrap();
+        match config {
+            OutboundConfig::Detailed { sample_rate, .. } => sample_rate,
+            _ => panic!("Expected Detailed variant"),
+        }
+    }
+
+    #[test]
+    fn test_outbound_config_sample_rate_float() {
+        let sample_rate =
+            get_sample_rate(r#"{"dsn": "https://key@sentry.io/123", "sample_rate": 0.25}"#);
+
+        assert_eq!(sample_rate, Some(SampleRateConfig::Uniform(0.25)));
+    }
+
+    #[test]
+    fn test_outbound_config_sample_rate_integer() {
+        // Integers should be accepted as rates, not just floats.
+        let sample_rate =
+            get_sample_rate(r#"{"dsn": "https://key@sentry.io/123", "sample_rate": 1}"#);
+
+        assert_eq!(sample_rate, Some(SampleRateConfig::Uniform(1.0)));
+    }
+
+    #[test]
+    fn test_outbound_config_sample_rate_map() {
+        let sample_rate = get_sample_rate(
+            r#"{"dsn": "https://key@sentry.io/123", "sample_rate": {"span": 0.05, "error": 0.5}}"#,
+        );
+
+        let expected = BTreeMap::from([("span".to_string(), 0.05), ("error".to_string(), 0.5)]);
+        assert_eq!(sample_rate, Some(SampleRateConfig::PerCategory(expected)));
+    }
+
+    #[test]
+    // Jail closures return figment::Error, which is large by nature.
+    #[allow(clippy::result_large_err)]
+    fn test_from_args_sample_rate_yaml() {
+        // Exercise the figment/yaml deserializer used in production, rather
+        // than serde_json which takes a different code path.
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "config.yaml",
+                r#"
+keys:
+  - inbound: https://inbound@sentry.io/1234
+    outbound:
+      - https://plain@sentry.io/1
+      - dsn: https://uniform@sentry.io/2
+        sample_rate: 0.5
+      - dsn: https://mapped@sentry.io/3
+        sample_rate:
+          span: 0.05
+"#,
+            )?;
+            let args = Args {
+                config: "config.yaml".to_string(),
+                verbose: false,
+            };
+            let config = from_args(&args).expect("config should parse");
+            let outbound = &config.keys[0].outbound;
+
+            assert_eq!(
+                outbound[0],
+                OutboundConfig::Dsn(Some("https://plain@sentry.io/1".to_string()))
+            );
+            match &outbound[1] {
+                OutboundConfig::Detailed { sample_rate, .. } => {
+                    assert_eq!(*sample_rate, Some(SampleRateConfig::Uniform(0.5)));
+                }
+                _ => panic!("Expected Detailed variant"),
+            }
+            match &outbound[2] {
+                OutboundConfig::Detailed { sample_rate, .. } => {
+                    let expected = BTreeMap::from([("span".to_string(), 0.05)]);
+                    assert_eq!(*sample_rate, Some(SampleRateConfig::PerCategory(expected)));
+                }
+                _ => panic!("Expected Detailed variant"),
+            }
+
+            Ok(())
+        });
     }
 }

--- a/src/dsn.rs
+++ b/src/dsn.rs
@@ -5,9 +5,11 @@ use std::str::FromStr;
 
 use hyper::{HeaderMap, Uri};
 use regex::Regex;
+use tracing::{error, warn};
 use url::Url;
 
 use crate::config::{ConfigData, OutboundConfig};
+use crate::sampling::{self, SampleRates};
 
 /// DSN components parsed from a DSN string
 #[derive(Debug, Clone, PartialEq)]
@@ -108,12 +110,20 @@ pub struct OutboundEntry {
     pub dsn: Dsn,
     pub categories: Vec<String>,
     pub multiplier: usize,
+
+    /// Sampling rates applied to traffic sent to this DSN.
+    /// `None` when the DSN is not sampled.
+    pub sample_rate: Option<SampleRates>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct DsnKeyRing {
     pub inbound: Dsn,
     pub outbound: Vec<OutboundEntry>,
+}
+
+fn parse_outbound(dsn: &str) -> Dsn {
+    dsn.parse::<Dsn>().expect("Invalid outbound DSN")
 }
 
 /// Convert a list of Config data keys into Dsn's that we can use
@@ -130,24 +140,40 @@ pub fn make_key_map(config: &ConfigData) -> HashMap<String, DsnKeyRing> {
             .outbound
             .iter()
             .filter_map(|item| match item {
-                OutboundConfig::Dsn(opt) => {
-                    opt.as_ref().map(|dsn_str| (dsn_str.clone(), vec![], 1))
-                }
+                OutboundConfig::Dsn(opt) => opt.as_ref().map(|dsn_str| OutboundEntry {
+                    dsn: parse_outbound(dsn_str),
+                    categories: vec![],
+                    multiplier: 1,
+                    sample_rate: None,
+                }),
                 OutboundConfig::Detailed {
                     dsn,
                     categories,
                     multiplier,
+                    sample_rate,
                 } => {
-                    let categories = categories.clone().unwrap_or(vec![]);
-                    Some((dsn.clone(), categories, *multiplier))
-                }
-            })
-            .map(|(outbound_str, categories, multiplier)| {
-                let dsn = outbound_str.parse::<Dsn>().expect("Invalid outbound DSN");
-                OutboundEntry {
-                    dsn,
-                    categories,
-                    multiplier,
+                    let mut problems = Vec::new();
+                    let sample_rate = sample_rate
+                        .as_ref()
+                        .map(|config| sampling::normalize(config, &mut problems));
+                    for problem in problems {
+                        warn!("Outbound DSN {dsn}: {problem}");
+                    }
+                    let multiplier = if sample_rate.is_some() && *multiplier > 1 {
+                        error!(
+                            "Outbound DSN {dsn}: multiplier cannot be combined with sample_rate, ignoring multiplier {multiplier}"
+                        );
+                        1
+                    } else {
+                        *multiplier
+                    };
+
+                    Some(OutboundEntry {
+                        dsn: parse_outbound(dsn),
+                        categories: categories.clone().unwrap_or_default(),
+                        multiplier,
+                        sample_rate,
+                    })
                 }
             })
             .collect::<Vec<OutboundEntry>>();
@@ -172,6 +198,9 @@ pub fn format_key_map(keymap: &HashMap<String, DsnKeyRing>) -> String {
             out.push_str(format!("- {}\n", outbound.dsn).as_ref());
             if !outbound.categories.is_empty() {
                 out.push_str(format!("  categories: {:?}\n", outbound.categories).as_ref());
+            }
+            if let Some(sample_rate) = &outbound.sample_rate {
+                out.push_str(format!("  sample_rate: {sample_rate}\n").as_ref());
             }
             if outbound.multiplier > 1 {
                 out.push_str(format!("  multiplier: {}\n", outbound.multiplier).as_ref());
@@ -216,8 +245,9 @@ pub fn from_request(uri: &Uri, headers: &HeaderMap) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ConfigData, ConfigKeyPair, OutboundConfig};
+    use crate::config::{ConfigData, ConfigKeyPair, OutboundConfig, SampleRateConfig};
     use crate::logging::LogFormat;
+    use std::collections::BTreeMap;
 
     fn make_test_config() -> ConfigData {
         ConfigData {
@@ -362,11 +392,13 @@ mod tests {
                     dsn: "https://ghijkl@sentry.io/567".to_string(),
                     categories: Some(vec!["event".to_string(), "transaction".to_string()]),
                     multiplier: 1,
+                    sample_rate: None,
                 },
                 OutboundConfig::Detailed {
                     dsn: "https://mnopq@sentry.io/890".to_string(),
                     categories: Some(vec!["replay".to_string()]),
                     multiplier: 1,
+                    sample_rate: None,
                 },
             ],
         }];
@@ -392,6 +424,7 @@ mod tests {
                     dsn: "https://key333@sentry.io/3333".to_string(),
                     categories: Some(vec!["error".to_string(), "span".to_string()]),
                     multiplier: 1,
+                    sample_rate: None,
                 },
             ],
         }];
@@ -407,6 +440,88 @@ mod tests {
         assert_eq!(key_value.outbound[0].categories.len(), 0);
         assert_eq!(key_value.outbound[1].dsn.public_key, "key333");
         assert_eq!(key_value.outbound[1].categories, vec!["error", "span"]);
+    }
+
+    /// Build a keymap with a single detailed outbound DSN.
+    fn key_map_with(multiplier: usize, sample_rate: Option<SampleRateConfig>) -> DsnKeyRing {
+        let mut config = make_test_config();
+        config.keys = vec![ConfigKeyPair {
+            inbound: "https://abcdef@sentry.io/1234".to_string(),
+            outbound: vec![OutboundConfig::Detailed {
+                dsn: "https://ghijkl@sentry.io/567".to_string(),
+                categories: None,
+                multiplier,
+                sample_rate,
+            }],
+        }];
+        let mut keymap = make_key_map(&config);
+
+        keymap.remove("abcdef").expect("Should have a value")
+    }
+
+    #[test]
+    fn make_key_map_with_sample_rate_float() {
+        let keyring = key_map_with(1, Some(SampleRateConfig::Uniform(0.5)));
+        let rates = keyring.outbound[0]
+            .sample_rate
+            .as_ref()
+            .expect("should have rates");
+
+        assert_eq!(rates.rate_for("error"), 0.5);
+        assert_eq!(rates.rate_for("span"), 0.5);
+    }
+
+    #[test]
+    fn make_key_map_with_sample_rate_map() {
+        let rates = BTreeMap::from([("span".to_string(), 0.05)]);
+        let keyring = key_map_with(1, Some(SampleRateConfig::PerCategory(rates)));
+        let rates = keyring.outbound[0]
+            .sample_rate
+            .as_ref()
+            .expect("should have rates");
+
+        assert_eq!(rates.rate_for("span"), 0.05);
+        assert_eq!(
+            rates.rate_for("error"),
+            1.0,
+            "unlisted categories are not sampled"
+        );
+    }
+
+    #[test]
+    fn make_key_map_no_sample_rate() {
+        let keyring = key_map_with(1, None);
+
+        assert_eq!(keyring.outbound[0].sample_rate, None);
+    }
+
+    #[test]
+    fn make_key_map_clamps_out_of_range_sample_rate() {
+        let keyring = key_map_with(1, Some(SampleRateConfig::Uniform(2.0)));
+        let rates = keyring.outbound[0]
+            .sample_rate
+            .as_ref()
+            .expect("should have rates");
+
+        assert_eq!(rates.rate_for("error"), 1.0);
+    }
+
+    #[test]
+    fn make_key_map_sample_rate_and_multiplier_conflict() {
+        let keyring = key_map_with(4, Some(SampleRateConfig::Uniform(0.5)));
+
+        assert_eq!(
+            keyring.outbound[0].multiplier, 1,
+            "multiplier should be ignored when sampling"
+        );
+        assert!(keyring.outbound[0].sample_rate.is_some());
+    }
+
+    #[test]
+    fn make_key_map_multiplier_without_sample_rate_preserved() {
+        let keyring = key_map_with(4, None);
+
+        assert_eq!(keyring.outbound[0].multiplier, 4);
     }
 
     #[test]
@@ -510,5 +625,38 @@ mod tests {
         assert!(output.contains("Outbound:\n"));
         assert!(output.contains("- https://ghijkl@sentry.io/567\n"));
         assert!(output.contains("- https://mnopq@sentry.io/890\n"));
+    }
+
+    #[test]
+    fn test_format_key_map_with_sample_rate() {
+        let mut config = make_test_config();
+        config.keys = vec![ConfigKeyPair {
+            inbound: "https://abcdef@sentry.io/1234".to_string(),
+            outbound: vec![
+                OutboundConfig::Detailed {
+                    dsn: "https://ghijkl@sentry.io/567".to_string(),
+                    categories: None,
+                    multiplier: 1,
+                    sample_rate: Some(SampleRateConfig::Uniform(0.5)),
+                },
+                OutboundConfig::Detailed {
+                    dsn: "https://mnopq@sentry.io/890".to_string(),
+                    categories: None,
+                    multiplier: 1,
+                    sample_rate: Some(SampleRateConfig::PerCategory(BTreeMap::from([(
+                        "span".to_string(),
+                        0.05,
+                    )]))),
+                },
+            ],
+        }];
+        let key_map = make_key_map(&config);
+        let output = format_key_map(&key_map);
+
+        assert!(output.contains("  sample_rate: 0.5\n"), "{output}");
+        assert!(
+            output.contains("  sample_rate: {span: 0.05} (default 1)\n"),
+            "{output}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod envelope;
 mod logging;
 mod metrics;
 mod request;
+mod sampling;
 mod service;
 mod state;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -14,7 +14,8 @@ use uuid::Uuid;
 
 use crate::config::ConfigData;
 use crate::dsn;
-use crate::envelope::Envelope;
+use crate::envelope::{Envelope, EnvelopeItem};
+use crate::sampling::{self, SampleRates};
 
 /// Several headers should not be forwarded as they can cause data truncation, or incorrect behavior.
 const NO_COPY_HEADERS: [&str; 3] = ["host", "x-forwarded-for", "content-length"];
@@ -90,6 +91,7 @@ pub fn update_envelope(
     outbound_dsn: &dsn::Dsn,
     categories: &[String],
     replace_item_id: bool,
+    sample_rate: Option<&SampleRates>,
 ) -> Option<Envelope> {
     // If we need to replace the event_id generate a new v4 uuid
     let new_event_id = if replace_item_id {
@@ -113,46 +115,125 @@ pub fn update_envelope(
         envelope.header["event_id"] = Value::String(event_id);
     }
 
-    // Modify the envelope items (applying category filters and sample_rate soon)
-    envelope.items = envelope
+    // Apply category filtering.
+    envelope
         .items
-        .into_iter()
-        .filter(|item| {
-            // Apply category filtering
-            let item_type = item
-                .header
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            categories.is_empty() || categories.contains(&item_type.to_string())
-        })
-        // TODO implement sample rates
-        .map(|mut item| {
-            if new_event_id.is_none() {
-                return item;
-            }
-            // Replace event_id in the event body to align with the envelope header.
-            if let Some(event_id) = new_event_id.clone()
-                && let Ok(mut item_body) = serde_json::from_slice::<Value>(item.body.as_ref())
-                && let Some(old_id) = item_body.get("event_id")
-            {
-                item_body["event_id"] = if old_id.to_string().contains("-") {
-                    Value::String(event_id.clone())
-                } else {
-                    Value::String(event_id.replace("-", "").clone())
-                };
-                item.body = Bytes::from(serde_json::to_vec(&item_body).unwrap());
-            }
-            item
-        })
-        .collect();
+        .retain(|item| categories.is_empty() || categories.contains(&item_type(item).to_string()));
 
     // If the envelope has had all items removed we don't send it.
     if envelope.items.is_empty() {
         return None;
     }
 
+    // Sampling is applied after category filtering so that the primary item is
+    // chosen from the items that will actually be sent.
+    if let Some(rates) = sample_rate
+        && rates.is_active()
+    {
+        let category = primary_category(&envelope.items);
+        let rate = rates.rate_for(category);
+        if !sampling::roll(rate) {
+            metrics::counter!(
+                "handle_proxy.outbound_request.sampled_out",
+                "outbound_host" => outbound_dsn.host.clone(),
+                "category" => category.to_string(),
+            )
+            .increment(1);
+            debug!(
+                "Sampling out envelope for {0} with rate {rate}",
+                outbound_dsn.host
+            );
+
+            return None;
+        }
+        scale_trace_sample_rate(&mut envelope.header, rate);
+    }
+
+    // Replace event ids when the envelope is being multiplied.
+    if new_event_id.is_some() {
+        envelope.items = envelope
+            .items
+            .into_iter()
+            .map(|mut item| {
+                // Replace event_id in the event body to align with the envelope header.
+                if let Some(event_id) = new_event_id.clone()
+                    && let Ok(mut item_body) = serde_json::from_slice::<Value>(item.body.as_ref())
+                    && let Some(old_id) = item_body.get("event_id")
+                {
+                    item_body["event_id"] = if old_id.to_string().contains("-") {
+                        Value::String(event_id.clone())
+                    } else {
+                        Value::String(event_id.replace("-", "").clone())
+                    };
+                    item.body = Bytes::from(serde_json::to_vec(&item_body).unwrap());
+                }
+                item
+            })
+            .collect();
+    }
+
     Some(envelope)
+}
+
+/// The `type` header of an envelope item.
+fn item_type(item: &EnvelopeItem) -> &str {
+    item.header
+        .get("type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+}
+
+/// The category that a sampling decision is made against.
+///
+/// Attachments accompany another item, so they are skipped in favour of the
+/// item they belong to. Dropping an event but keeping its attachment would
+/// leave the attachment orphaned.
+fn primary_category(items: &[EnvelopeItem]) -> &str {
+    items
+        .iter()
+        .map(item_type)
+        .find(|item_type| *item_type != "attachment")
+        .unwrap_or_else(|| items.first().map(item_type).unwrap_or(""))
+}
+
+/// Multiply the `trace.sample_rate` envelope header by the rate that mirror
+/// sampling used, so that the header reflects the rate data arrived at.
+///
+/// Sentry serializes this value as a string so that it survives a trip through
+/// the `baggage` header, but numbers are handled as well. The value is written
+/// back in the shape it was read in.
+fn scale_trace_sample_rate(header: &mut Value, factor: f64) {
+    // Nothing to do, and rewriting would reformat the value for no reason.
+    if factor >= 1.0 {
+        return;
+    }
+    let Some(trace) = header.get_mut("trace") else {
+        return;
+    };
+    let current = match trace.get("sample_rate") {
+        Some(Value::String(value)) => value.parse::<f64>().ok().map(|rate| (rate, true)),
+        Some(Value::Number(value)) => value.as_f64().map(|rate| (rate, false)),
+        Some(other) => {
+            warn!("Unexpected trace.sample_rate value {other:?}");
+            None
+        }
+        None => None,
+    };
+    // Envelopes without a sample rate are left alone. Adding one would claim a
+    // client side sample rate that was never used.
+    let Some((current, was_string)) = current else {
+        return;
+    };
+
+    let updated = (current * factor).clamp(0.0, 1.0);
+    trace["sample_rate"] = if was_string {
+        Value::String(format!("{updated}"))
+    } else {
+        match serde_json::Number::from_f64(updated) {
+            Some(number) => Value::Number(number),
+            None => return,
+        }
+    };
 }
 
 fn replace_public_key(target: &str, outbound: &dsn::Dsn) -> String {
@@ -290,6 +371,7 @@ mod tests {
     use http_body_util::Full;
 
     use super::*;
+    use crate::config::SampleRateConfig;
     use crate::envelope;
 
     fn make_test_config() -> ConfigData {
@@ -525,7 +607,7 @@ mod tests {
         body.extend_from_slice(b"{}\n");
         body.extend_from_slice(b"{}\n");
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &[], true);
+        let result = update_envelope(envelope, &outbound, &[], true, None);
 
         assert!(result.is_some());
         let envelope = result.unwrap();
@@ -541,7 +623,7 @@ mod tests {
         let lines = vec![r#"{"key":"value"}"#, r#"{"second":"line"}"#, r#"{}"#];
         let body = string_list_to_bytes(lines);
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &[], true);
+        let result = update_envelope(envelope, &outbound, &[], true, None);
 
         assert!(result.is_some());
         let updated = result.expect("should be some");
@@ -564,7 +646,7 @@ mod tests {
         ];
         let body = string_list_to_bytes(lines);
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &[], false);
+        let result = update_envelope(envelope, &outbound, &[], false, None);
 
         assert!(result.is_some());
         let updated = result.expect("should be updated");
@@ -590,7 +672,7 @@ mod tests {
         ];
         let body = string_list_to_bytes(lines);
         let envelope = envelope::parse(&body).expect("should parse");
-        let result = update_envelope(envelope, &outbound, &[], false);
+        let result = update_envelope(envelope, &outbound, &[], false, None);
 
         assert!(result.is_some());
 
@@ -618,7 +700,7 @@ mod tests {
         ];
         let body = string_list_to_bytes(lines);
         let envelope = envelope::parse(&body).expect("should parse");
-        let result = update_envelope(envelope, &outbound, &[], false);
+        let result = update_envelope(envelope, &outbound, &[], false, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -777,7 +859,7 @@ mod tests {
 
         let categories: Vec<String> = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, false);
+        let result = update_envelope(envelope, &outbound, &categories, false, None);
 
         assert!(result.is_some(), "Should return Some for valid input");
         let updated = result.unwrap();
@@ -808,7 +890,7 @@ mod tests {
 
         let categories = vec!["event".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, false);
+        let result = update_envelope(envelope, &outbound, &categories, false, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -833,7 +915,7 @@ mod tests {
 
         let categories = vec!["transaction".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, false);
+        let result = update_envelope(envelope, &outbound, &categories, false, None);
         assert!(
             result.is_none(),
             "all items filtered, envelope is not needed"
@@ -853,7 +935,7 @@ mod tests {
 
         let categories = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -882,7 +964,7 @@ mod tests {
 
         let categories = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -921,7 +1003,7 @@ mod tests {
 
         let categories = vec!["attachment".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, false);
+        let result = update_envelope(envelope, &outbound, &categories, false, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -949,7 +1031,7 @@ mod tests {
 
         let categories: Vec<String> = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -990,7 +1072,7 @@ mod tests {
 
         let categories = vec!["attachment".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -1019,7 +1101,7 @@ mod tests {
 
         let categories = vec!["attachment".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -1050,7 +1132,7 @@ mod tests {
 
         let categories = vec!["event".to_string()];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
         assert!(result.is_some());
 
         let updated = result.unwrap();
@@ -1084,7 +1166,7 @@ mod tests {
 
         let categories = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
         assert!(result.is_some());
         let updated = result.unwrap();
         assert_eq!(updated.items.len(), 2);
@@ -1123,7 +1205,7 @@ mod tests {
 
         let categories = vec![];
         let envelope = envelope::parse(&body).expect("body should parse");
-        let result = update_envelope(envelope, &outbound, &categories, true);
+        let result = update_envelope(envelope, &outbound, &categories, true, None);
 
         assert!(result.is_some());
         let updated = result.unwrap();
@@ -1132,5 +1214,284 @@ mod tests {
             *updated.header.get("event_id").unwrap() != Value::String("original-id".to_string()),
             "event id should be changed"
         );
+    }
+
+    fn uniform_rates(rate: f64) -> SampleRates {
+        let mut problems = Vec::new();
+        sampling::normalize(&SampleRateConfig::Uniform(rate), &mut problems)
+    }
+
+    fn category_rates(rates: &[(&str, f64)]) -> SampleRates {
+        let mut problems = Vec::new();
+        let config = SampleRateConfig::PerCategory(
+            rates
+                .iter()
+                .map(|(category, rate)| (category.to_string(), *rate))
+                .collect(),
+        );
+
+        sampling::normalize(&config, &mut problems)
+    }
+
+    /// An envelope with a single item of `item_type`.
+    fn sampling_envelope(item_type: &str) -> Envelope {
+        let body = string_list_to_bytes(vec![
+            r#"{"dsn":"https://deadbeef@ingest.sentry.io/123"}"#,
+            &format!(r#"{{"type":"{item_type}","length":4}}"#),
+            "test",
+        ]);
+
+        envelope::parse(&body).expect("body should parse")
+    }
+
+    fn test_dsn() -> dsn::Dsn {
+        "https://outbound@o789.ingest.sentry.io/6789"
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_zero_drops() {
+        let result = update_envelope(
+            sampling_envelope("error"),
+            &test_dsn(),
+            &[],
+            false,
+            Some(&category_rates(&[("error", 0.0)])),
+        );
+
+        assert!(result.is_none(), "a 0.0 rate should drop the envelope");
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_one_keeps() {
+        let result = update_envelope(
+            sampling_envelope("error"),
+            &test_dsn(),
+            &[],
+            false,
+            Some(&category_rates(&[("error", 1.0)])),
+        );
+
+        assert!(result.is_some(), "a 1.0 rate should keep the envelope");
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_unlisted_category_kept() {
+        let result = update_envelope(
+            sampling_envelope("error"),
+            &test_dsn(),
+            &[],
+            false,
+            Some(&category_rates(&[("span", 0.0)])),
+        );
+
+        assert!(
+            result.is_some(),
+            "categories without a rate should not be sampled"
+        );
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_uniform_zero_drops() {
+        let result = update_envelope(
+            sampling_envelope("transaction"),
+            &test_dsn(),
+            &[],
+            false,
+            Some(&uniform_rates(0.0)),
+        );
+
+        assert!(result.is_none(), "uniform rates apply to every category");
+    }
+
+    /// The sampling decision is made per envelope using the primary item, so
+    /// that an attachment is never separated from the event it belongs to.
+    #[test]
+    fn test_update_envelope_sample_rate_uses_primary_item() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"{\"dsn\":\"value\"}\n");
+        body.extend_from_slice(b"{\"type\":\"attachment\",\"length\":5}\n");
+        body.extend_from_slice(b"hello");
+        body.push(b'\n');
+        body.extend_from_slice(b"{\"type\":\"event\",\"length\":4}\n");
+        body.extend_from_slice(b"test");
+
+        // The leading attachment does not drive the decision.
+        let envelope = envelope::parse(&body).expect("body should parse");
+        let result = update_envelope(
+            envelope,
+            &test_dsn(),
+            &[],
+            false,
+            Some(&category_rates(&[("attachment", 0.0)])),
+        );
+        assert!(
+            result.is_some(),
+            "attachments should not make the decision for the envelope"
+        );
+
+        // Dropping the event takes its attachment along with it.
+        let envelope = envelope::parse(&body).expect("body should parse");
+        let result = update_envelope(
+            envelope,
+            &test_dsn(),
+            &[],
+            false,
+            Some(&category_rates(&[("event", 0.0)])),
+        );
+        assert!(
+            result.is_none(),
+            "the whole envelope is dropped, including attachments"
+        );
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_applied_after_category_filter() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"{\"dsn\":\"value\"}\n");
+        body.extend_from_slice(b"{\"type\":\"attachment\",\"length\":5}\n");
+        body.extend_from_slice(b"hello");
+        body.push(b'\n');
+        body.extend_from_slice(b"{\"type\":\"event\",\"length\":4}\n");
+        body.extend_from_slice(b"test");
+
+        let envelope = envelope::parse(&body).expect("body should parse");
+        let result = update_envelope(
+            envelope,
+            &test_dsn(),
+            &["event".to_string()],
+            false,
+            Some(&category_rates(&[("attachment", 0.0)])),
+        );
+
+        assert!(
+            result.is_some(),
+            "the attachment is filtered out before sampling decides"
+        );
+    }
+
+    /// Sentry sends the dynamic sampling context as strings so that it can
+    /// survive a trip through the baggage header.
+    #[test]
+    fn test_scale_trace_sample_rate_string() {
+        let mut header =
+            serde_json::json!({"trace": {"public_key": "abcdef", "sample_rate": "0.5"}});
+        scale_trace_sample_rate(&mut header, 0.5);
+
+        assert_eq!(
+            header["trace"]["sample_rate"],
+            Value::String("0.25".to_string()),
+            "the rate should be multiplied and stay a string"
+        );
+    }
+
+    #[test]
+    fn test_scale_trace_sample_rate_numeric() {
+        let mut header = serde_json::json!({"trace": {"public_key": "abcdef", "sample_rate": 0.5}});
+        scale_trace_sample_rate(&mut header, 0.5);
+
+        assert_eq!(
+            header["trace"]["sample_rate"],
+            serde_json::json!(0.25),
+            "numeric rates should stay numeric"
+        );
+    }
+
+    #[test]
+    fn test_scale_trace_sample_rate_not_scaled_at_one() {
+        let mut header =
+            serde_json::json!({"trace": {"public_key": "abcdef", "sample_rate": "0.5"}});
+        scale_trace_sample_rate(&mut header, 1.0);
+
+        assert_eq!(
+            header["trace"]["sample_rate"],
+            Value::String("0.5".to_string()),
+            "an unsampled rate should not reformat the value"
+        );
+    }
+
+    #[test]
+    fn test_scale_trace_sample_rate_no_trace_header() {
+        let mut header = serde_json::json!({"event_id": "abcdef"});
+        scale_trace_sample_rate(&mut header, 0.5);
+
+        assert!(
+            header.get("trace").is_none(),
+            "a trace header should not be invented"
+        );
+    }
+
+    #[test]
+    fn test_scale_trace_sample_rate_missing_field() {
+        let mut header = serde_json::json!({"trace": {"public_key": "abcdef"}});
+        scale_trace_sample_rate(&mut header, 0.5);
+
+        assert!(
+            header["trace"].get("sample_rate").is_none(),
+            "a sample rate should not be added when the client did not send one"
+        );
+    }
+
+    #[test]
+    fn test_scale_trace_sample_rate_unparseable() {
+        let mut header =
+            serde_json::json!({"trace": {"public_key": "abcdef", "sample_rate": "bogus"}});
+        scale_trace_sample_rate(&mut header, 0.5);
+
+        assert_eq!(
+            header["trace"]["sample_rate"],
+            Value::String("bogus".to_string()),
+            "unparseable rates should be left alone"
+        );
+    }
+
+    /// Every envelope that survives sampling should carry the scaled rate.
+    #[test]
+    fn test_update_envelope_scales_trace_sample_rate() {
+        let body = string_list_to_bytes(vec![
+            r#"{"trace":{"public_key":"abcdef","sample_rate":"1.0"}}"#,
+            r#"{"type":"transaction","length":4}"#,
+            "test",
+        ]);
+        let rates = uniform_rates(0.5);
+
+        let mut kept = 0;
+        for _ in 0..50 {
+            let envelope = envelope::parse(&body).expect("body should parse");
+            let Some(updated) = update_envelope(envelope, &test_dsn(), &[], false, Some(&rates))
+            else {
+                continue;
+            };
+            kept += 1;
+            assert_eq!(
+                updated.header["trace"]["sample_rate"],
+                Value::String("0.5".to_string()),
+                "kept envelopes should report the mirrored rate"
+            );
+        }
+
+        assert!(kept > 0, "a 0.5 rate should keep some envelopes");
+    }
+
+    #[test]
+    fn test_update_envelope_sample_rate_half_is_probabilistic() {
+        let rates = uniform_rates(0.5);
+        let mut kept = 0;
+        for _ in 0..200 {
+            let result = update_envelope(
+                sampling_envelope("error"),
+                &test_dsn(),
+                &[],
+                false,
+                Some(&rates),
+            );
+            if result.is_some() {
+                kept += 1;
+            }
+        }
+
+        assert!(kept > 0, "a 0.5 rate should keep some envelopes");
+        assert!(kept < 200, "a 0.5 rate should drop some envelopes");
     }
 }

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -115,7 +115,7 @@ pub fn roll(rate: f64) -> bool {
         return false;
     }
 
-    rate < rand::rng().random::<f64>()
+    rate > rand::rng().random::<f64>()
 }
 
 #[cfg(test)]

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -1,0 +1,243 @@
+use rand::Rng;
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::config::SampleRateConfig;
+
+/// Normalized and validated sampling rates for a single outbound DSN.
+///
+/// Both configuration shapes collapse into this one. A uniform rate becomes
+/// `default_rate` with an empty map, while a per-category map leaves
+/// `default_rate` at 1.0 so that categories which are not listed are not
+/// sampled.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SampleRates {
+    /// The rate used for categories missing from `per_category`.
+    default_rate: f64,
+
+    /// Rates for individual envelope item categories.
+    per_category: BTreeMap<String, f64>,
+}
+
+impl SampleRates {
+    /// The sample rate for a category. Categories that have no explicit
+    /// rate use the default rate.
+    pub fn rate_for(&self, category: &str) -> f64 {
+        *self
+            .per_category
+            .get(category)
+            .unwrap_or(&self.default_rate)
+    }
+
+    /// Whether any configured rate can drop data. Lets request handling skip
+    /// sampling work entirely when rates are all 1.0.
+    pub fn is_active(&self) -> bool {
+        self.default_rate < 1.0 || self.per_category.values().any(|rate| *rate < 1.0)
+    }
+}
+
+impl fmt::Display for SampleRates {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.per_category.is_empty() {
+            return write!(f, "{}", self.default_rate);
+        }
+        let pairs = self
+            .per_category
+            .iter()
+            .map(|(category, rate)| format!("{category}: {rate}"))
+            .collect::<Vec<String>>();
+
+        write!(
+            f,
+            "{{{}}} (default {})",
+            pairs.join(", "),
+            self.default_rate
+        )
+    }
+}
+
+/// Convert configuration into validated rates.
+///
+/// Rates outside of 0.0 - 1.0 are clamped to the nearest boundary and values
+/// that are not numbers are ignored. Each correction is appended to `problems`
+/// so that callers can log them with the DSN they belong to.
+pub fn normalize(config: &SampleRateConfig, problems: &mut Vec<String>) -> SampleRates {
+    match config {
+        SampleRateConfig::Uniform(rate) => SampleRates {
+            default_rate: clamp_rate(None, *rate, problems),
+            per_category: BTreeMap::new(),
+        },
+        SampleRateConfig::PerCategory(rates) => SampleRates {
+            default_rate: 1.0,
+            per_category: rates
+                .iter()
+                .map(|(category, rate)| {
+                    (
+                        category.clone(),
+                        clamp_rate(Some(category), *rate, problems),
+                    )
+                })
+                .collect(),
+        },
+    }
+}
+
+/// Clamp a rate into 0.0 - 1.0, recording a message when the value is changed.
+fn clamp_rate(category: Option<&str>, rate: f64, problems: &mut Vec<String>) -> f64 {
+    let target = match category {
+        Some(name) => format!("category {name}"),
+        None => "all categories".to_string(),
+    };
+    // clamp() returns NaN for NaN, which would silently drop all traffic.
+    if !rate.is_finite() {
+        problems.push(format!(
+            "sample_rate {rate} for {target} is not a number, using 1.0"
+        ));
+        return 1.0;
+    }
+    if !(0.0..=1.0).contains(&rate) {
+        let clamped = rate.clamp(0.0, 1.0);
+        problems.push(format!(
+            "sample_rate {rate} for {target} is outside of 0.0 - 1.0, clamped to {clamped}"
+        ));
+        return clamped;
+    }
+
+    rate
+}
+
+/// Draw against the thread local rng to decide if an item is kept.
+pub fn roll(rate: f64) -> bool {
+    if rate >= 1.0 {
+        return true;
+    }
+    if rate <= 0.0 {
+        return false;
+    }
+
+    rate < rand::rng().random::<f64>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn per_category(rates: &[(&str, f64)]) -> SampleRateConfig {
+        SampleRateConfig::PerCategory(
+            rates
+                .iter()
+                .map(|(category, rate)| (category.to_string(), *rate))
+                .collect(),
+        )
+    }
+
+    fn normalized(config: &SampleRateConfig) -> SampleRates {
+        let mut problems = Vec::new();
+        normalize(config, &mut problems)
+    }
+
+    #[test]
+    fn test_rate_for_uniform() {
+        let rates = normalized(&SampleRateConfig::Uniform(0.25));
+
+        assert_eq!(rates.rate_for("error"), 0.25);
+        assert_eq!(rates.rate_for("transaction"), 0.25);
+        assert_eq!(rates.rate_for(""), 0.25);
+    }
+
+    #[test]
+    fn test_rate_for_map_defaults_to_one() {
+        let rates = normalized(&per_category(&[("span", 0.05)]));
+
+        assert_eq!(rates.rate_for("span"), 0.05);
+        assert_eq!(
+            rates.rate_for("error"),
+            1.0,
+            "categories without a rate are not sampled"
+        );
+        assert_eq!(
+            rates.rate_for(""),
+            1.0,
+            "payloads without a category are not sampled"
+        );
+    }
+
+    #[test]
+    fn test_normalize_clamps_above_one() {
+        let mut problems = Vec::new();
+        let rates = normalize(&per_category(&[("error", 1.5)]), &mut problems);
+
+        assert_eq!(rates.rate_for("error"), 1.0);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("category error"), "{}", problems[0]);
+    }
+
+    #[test]
+    fn test_normalize_clamps_below_zero() {
+        let mut problems = Vec::new();
+        let rates = normalize(&SampleRateConfig::Uniform(-0.5), &mut problems);
+
+        assert_eq!(rates.rate_for("error"), 0.0);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("clamped to 0"), "{}", problems[0]);
+    }
+
+    #[test]
+    fn test_normalize_non_finite() {
+        let mut problems = Vec::new();
+        let rates = normalize(
+            &per_category(&[("error", f64::NAN), ("span", f64::INFINITY)]),
+            &mut problems,
+        );
+
+        assert_eq!(
+            rates.rate_for("error"),
+            1.0,
+            "NaN should not drop all traffic"
+        );
+        assert_eq!(rates.rate_for("span"), 1.0);
+        assert_eq!(problems.len(), 2);
+    }
+
+    #[test]
+    fn test_normalize_in_range_no_problems() {
+        let mut problems = Vec::new();
+        normalize(
+            &per_category(&[("error", 0.0), ("span", 0.5), ("log", 1.0)]),
+            &mut problems,
+        );
+
+        assert!(problems.is_empty(), "{problems:?}");
+    }
+
+    #[test]
+    fn test_is_active() {
+        assert!(!normalized(&SampleRateConfig::Uniform(1.0)).is_active());
+        assert!(!normalized(&per_category(&[("error", 1.0)])).is_active());
+        assert!(normalized(&SampleRateConfig::Uniform(0.5)).is_active());
+        assert!(normalized(&per_category(&[("error", 0.0)])).is_active());
+    }
+
+    #[test]
+    fn test_roll_deterministic_extremes() {
+        for _ in 0..100 {
+            assert!(roll(1.0));
+            assert!(!roll(0.0));
+        }
+    }
+
+    #[test]
+    fn test_display_uniform() {
+        assert_eq!(
+            normalized(&SampleRateConfig::Uniform(0.5)).to_string(),
+            "0.5"
+        );
+    }
+
+    #[test]
+    fn test_display_per_category() {
+        let rates = normalized(&per_category(&[("span", 0.05), ("error", 0.5)]));
+
+        assert_eq!(rates.to_string(), "{error: 0.5, span: 0.05} (default 1)");
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -225,7 +225,10 @@ where
                 found_body = true;
             }
         } else {
-            metrics::counter!("handle_proxy.outbound_request.failed").increment(1);
+            metrics::counter!(
+                "handle_proxy.outbound_request.failed",
+                "outbound_host" => resp_hostname.clone()
+            ).increment(1);
             warn!("Could not make request: {0:?}", response_res.err());
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,6 +14,7 @@ use hyper_tls::HttpsConnector;
 use crate::dsn;
 use crate::envelope;
 use crate::request;
+use crate::sampling;
 use crate::state::AppState;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
@@ -152,7 +153,13 @@ where
                 let cloned = envelope.clone().unwrap();
 
                 // Generate a new body for the request if modifying envelopes is enabled.
-                match request::update_envelope(cloned, &outbound.dsn, &outbound.categories, i > 0) {
+                match request::update_envelope(
+                    cloned,
+                    &outbound.dsn,
+                    &outbound.categories,
+                    i > 0,
+                    outbound.sample_rate.as_ref(),
+                ) {
                     Some(envelope) => envelope.to_bytes(),
                     None => {
                         // Skip sending out requests for those that didn't yield an envelope
@@ -170,6 +177,22 @@ where
                     }
                 }
             } else {
+                // Payloads that aren't envelopes (minidumps, otlp) and have no items
+                // use `unknown` as a placeholder category
+                if let Some(rates) = &outbound.sample_rate
+                    && rates.is_active()
+                    && !sampling::roll(rates.rate_for("unknown"))
+                {
+                    metrics::counter!(
+                        "handle_proxy.outbound_request.sampled_out",
+                        "outbound_host" => outbound_host.clone(),
+                        "category" => "unknown",
+                    )
+                    .increment(1);
+                    debug!("Sampling out request for {}", outbound_host);
+
+                    continue;
+                }
                 body_bytes.clone()
             };
 
@@ -228,7 +251,8 @@ where
             metrics::counter!(
                 "handle_proxy.outbound_request.failed",
                 "outbound_host" => resp_hostname.clone()
-            ).increment(1);
+            )
+            .increment(1);
             warn!("Could not make request: {0:?}", response_res.err());
         }
     }

--- a/tests/fixtures/transaction-dsc.txt
+++ b/tests/fixtures/transaction-dsc.txt
@@ -1,0 +1,3 @@
+{"event_id":"1d2b3c58-41b3-40df-92b9-a6be3fe3490e","trace":{"trace_id":"6cf173d587eb48568a9b2e12dcfbea52","public_key":"390bf7f953b7492c9007d2cf69078adf","sample_rate":"1.0","environment":"production","release":"1.0.0"}}
+{"type":"transaction"}
+{"event_id":"1d2b3c5841b340df92b9a6be3fe3490e","type":"transaction","transaction":"GET /users","platform":"python","start_timestamp":1742921669.158209,"timestamp":1742921669.180536,"contexts":{"trace":{"trace_id":"6cf173d587eb48568a9b2e12dcfbea52","span_id":"438f40bd3b4a41ee","op":"http.server"}}}

--- a/tests/sampling-test.yaml
+++ b/tests/sampling-test.yaml
@@ -1,0 +1,14 @@
+---
+ip: 0.0.0.0
+port: 3001
+log_filter: info
+keys:
+  - inbound: http://390bf7f953b7492c9007d2cf69078adf@localhost:3001/456
+    outbound:
+      # Drop all errors via a 0.0 sample rate, but forward transactions.
+      - dsn: "http://d2030950546a6177f9cdb0663b069aed@localhost:8001/789"
+        sample_rate:
+          error: 0.0
+          transaction: 1.0
+      # Forward everything (no sampling)
+      - dsn: "http://e3141a61657b7288facec1774c17afbe@localhost:8002/789"

--- a/tests/sampling-trace-test.yaml
+++ b/tests/sampling-trace-test.yaml
@@ -1,0 +1,12 @@
+---
+ip: 0.0.0.0
+port: 3001
+log_filter: info
+keys:
+  - inbound: http://390bf7f953b7492c9007d2cf69078adf@localhost:3001/456
+    outbound:
+      # Sample all categories, so that trace.sample_rate is recalculated.
+      - dsn: "http://d2030950546a6177f9cdb0663b069aed@localhost:8001/789"
+        sample_rate: 0.5
+      # Forward everything (no sampling)
+      - dsn: "http://e3141a61657b7288facec1774c17afbe@localhost:8002/789"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,6 +112,46 @@ def multiplier_mirror_process():
 
 
 @pytest.fixture
+def sampling_mirror_process():
+    """Start the mirror application and ensure it shuts down after tests."""
+    config_path = Path(__file__).parent / "sampling-test.yaml"
+    process = subprocess.Popen(
+        ["cargo", "run", "--", f"--config={config_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    logger.info("Starting mirror")
+    wait_for_server(process, "localhost", 3001)
+
+    yield process
+
+    # Cleanup
+    logger.info("Teardown mirror")
+    kill_process(process)
+
+
+@pytest.fixture
+def sampling_trace_mirror_process():
+    """Start the mirror application and ensure it shuts down after tests."""
+    config_path = Path(__file__).parent / "sampling-trace-test.yaml"
+    process = subprocess.Popen(
+        ["cargo", "run", "--", f"--config={config_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    logger.info("Starting mirror")
+    wait_for_server(process, "localhost", 3001)
+
+    yield process
+
+    # Cleanup
+    logger.info("Teardown mirror")
+    kill_process(process)
+
+
+@pytest.fixture
 def stub_servers():
     """Start the two stub servers and ensure they shut down after tests."""
     timestamp = int(time.time())
@@ -452,6 +492,74 @@ def test_mirror_multiplies_envelopes(multiplier_mirror_process, stub_servers):
             f"Server2 request {i} item header should match server1"
         assert normalized_server2[2] == normalized_server1[2], \
             f"Server2 request {i} payload should match server1 after event_id normalization"
+
+
+def test_mirror_samples_envelopes(sampling_mirror_process, stub_servers):
+    """
+    Test that the mirror applies sample rates per category
+
+    server_one samples errors at 0.0 and transactions at 1.0, so it only
+    receives the transaction. server_two is unsampled and receives both.
+    """
+    fixture_path = Path(__file__).parent / "fixtures" / "error-python.txt"
+    response = send_envelope_to_mirror(fixture_path)
+    assert response.status_code == 200, f"Mirror returned {response.status_code}"
+
+    fixture_path = Path(__file__).parent / "fixtures" / "transaction-python.txt"
+    response = send_envelope_to_mirror(fixture_path)
+    assert response.status_code == 200, f"Mirror returned {response.status_code}"
+
+    # Give the mirror time to forward requests
+    time.sleep(1)
+
+    server_one, server_two = stub_servers
+    server1_requests = read_logs(server_one["logfile"])
+    server2_requests = read_logs(server_two["logfile"])
+
+    assert len(server1_requests) == 1, \
+        f"Server 1 should only receive the transaction, got {len(server1_requests)}"
+    assert len(server2_requests) == 2, \
+        f"Server 2 should receive both envelopes, got {len(server2_requests)}"
+
+    assert '"type":"transaction"' in server1_requests[0]["body"], \
+        "The error should have been sampled out"
+
+
+def test_mirror_recalculates_trace_sample_rate(sampling_trace_mirror_process, stub_servers):
+    """
+    Test that trace.sample_rate reflects the mirror sampling that was applied.
+
+    server_one samples at 0.5, so the envelopes it does receive should report
+    1.0 * 0.5. server_two is unsampled and keeps the original rate.
+    """
+    fixture_path = Path(__file__).parent / "fixtures" / "transaction-dsc.txt"
+    attempts = 20
+    for _ in range(attempts):
+        response = send_envelope_to_mirror(fixture_path)
+        assert response.status_code == 200, f"Mirror returned {response.status_code}"
+
+    # Give the mirror time to forward requests
+    time.sleep(1)
+
+    server_one, server_two = stub_servers
+    server1_requests = read_logs(server_one["logfile"])
+    server2_requests = read_logs(server_two["logfile"])
+
+    # Sampling at 0.5 over 20 attempts, the odds of receiving nothing are 2^-20
+    assert len(server1_requests) > 0, "Server 1 should receive some envelopes"
+    assert len(server1_requests) < attempts, "Server 1 should not receive every envelope"
+    assert len(server2_requests) == attempts, \
+        f"Server 2 should receive every envelope, got {len(server2_requests)}"
+
+    for request in server1_requests:
+        header, _, _ = parse_envelope(request["body"])
+        assert header["trace"]["sample_rate"] == "0.5", \
+            f"Sampled envelopes should report the mirrored rate, got {header['trace']['sample_rate']}"
+
+    for request in server2_requests:
+        header, _, _ = parse_envelope(request["body"])
+        assert header["trace"]["sample_rate"] == "1.0", \
+            "Unsampled envelopes should keep the original rate"
 
 
 def parse_envelope(envelope_body: str) -> tuple[dict, dict, dict]:


### PR DESCRIPTION
To replicate the behavior of the internal multiplexer within sentry, the mirror needs to offer sampling. Each outbound DSN can have a general sample rate or a per-category sample rate. The sampling rates for specific categories are not checked (just like category filters) for future compatibility.

Adding sampling will likely add a marginal amount of overhead when it is active, but unsampled usage should not be impacted.

